### PR TITLE
LUN-167 Patch the ContentFile class to work with unicode strings

### DIFF
--- a/filertags/signals.py
+++ b/filertags/signals.py
@@ -97,7 +97,7 @@ def _rewrite_file_content(filer_file, new_content):
 
 
 def _is_css(filer_file):
-    return _get_filer_file_name.endswith('.css')
+    return _get_filer_file_name(filer_file).endswith('.css')
 
 
 def _get_filer_file_name(file_):


### PR DESCRIPTION
The original fix aede3b9cfbe05c1099e9e17fe655467205bb5c73 committed on master fixed the problem on when filer uses S3 backends. It's broken for local file system.

This fix patches django.core.files.base.ContentFile to have the self.file with proper unicode encoded content.

As per http://bugs.python.org/issue1548891 cStringIO.StringIO constructor is broken, but writelines method works just fine.
Also see https://code.djangoproject.com/ticket/11739
