### PR TITLE
Delete old version of the file before saving the new one

### DIFF
--- a/filertags/signals.py
+++ b/filertags/signals.py
@@ -89,6 +89,7 @@ def _rewrite_file_content(filer_file, new_content):
         storage = filer_file.file.storage
         fp = ContentFile(new_content, filer_file.file.name)
         filer_file.file.file = fp
+        storage.delete(filer_file.file.name)
         filer_file.file.name = storage.save(filer_file.file.name, fp)
     # all code in filer.filemodels.File.save which percedes the call to
     # super(File, self).save will be executed BEFORE the resolve_resource_urls


### PR DESCRIPTION
Since filer no longer overwrites files with the same name (see FILE_OVERWRITE setting in s3boto storage backend)
=> it makes more sense to delete the prev file before saving again, thus avoiding the generation of a new file with a new auto-generated name.
